### PR TITLE
Fixes https://github.com/xiewuzhiying/Some-Peripherals/issues/2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ forge_version=1.20.1-47.2.0
 vs2_version=2.1.3-beta.1+a52f38bd68
 vs_core_version=1.1.0+8a93383ce5
 
-accelerated_raycasting_path=/AcceleratedRaycasting-0.0.1-dev.jar
+accelerated_raycasting_path=./AcceleratedRaycasting-0.0.1-dev.jar


### PR DESCRIPTION
The path for `AcceleratedRaycasting-0.0.1-dev.jar` was incorrectly specified as absolute.